### PR TITLE
Clarify what happens when a handler is attached during event dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This implementation results in promise rejections being marked as **handled** or
             1. Initialise _event_'s `promise` attribute to _promise_.
             1. Initialise _event_'s `reason` attribute to the value of _promise_'s [[PromiseResult]] internal slot.
             1. Dispatch _event_ at the current script's [global object](https://html.spec.whatwg.org/multipage/webappapis.html#global-object).
-            1. If event was canceled, then the error is handled. Otherwise, the error is not handled.
+            1. If event was canceled, then the promise rejection is handled. Otherwise, the promise rejection is not handled.
             1. if _p_'s [[PromiseIsHandled]] internal slot is false then add _p_ to the outstanding rejected promises weak set.
         1. Clear the about-to-be-notified rejected promises list.
 1. If _operation_ is `"handle"`,

--- a/README.md
+++ b/README.md
@@ -79,16 +79,16 @@ This implementation results in promise rejections being marked as **handled** or
     1. Add _promise_ to the about-to-be-notified rejected promises list.
     1. Queue a task to perform the following steps:
         1. For each entry _p_ in the about-to-be-notified rejected promises list,
-            1. Add _p_ to the outstanding rejected promises weak set.
             1. Let _event_ be a new trusted `PromiseRejectionEvent` object that does not bubble and is cancelable, and which has the event name `unhandledrejection`.
             1. Initialise _event_'s `promise` attribute to _promise_.
             1. Initialise _event_'s `reason` attribute to the value of _promise_'s [[PromiseResult]] internal slot.
             1. Dispatch _event_ at the current script's [global object](https://html.spec.whatwg.org/multipage/webappapis.html#global-object).
             1. If event was canceled, then the error is handled. Otherwise, the error is not handled.
+            1. if _p_'s [[PromiseIsHandled]] internal slot is false then add _p_ to the outstanding rejected promises weak set.
         1. Clear the about-to-be-notified rejected promises list.
 1. If _operation_ is `"handle"`,
     1. If the about-to-be-notified rejected promises list contains _promise_, remove _promise_ from the about-to-be-notified rejected promises list and return.
-    1. Assert: the outstanding rejected promises weak set contains _promise_.
+    1. If the outstanding rejected promises weak set does not contain _promise_ then return.
     1. Remove _promise_ from the outstanding rejected promises weak set.
     1. Let _event_ be a new trusted `PromiseRejectionEvent` object that does not bubble and is not cancelable, and which has the event name `rejectionhandled`.
     1. Initialise _event_'s `promise` attribute to _promise_.


### PR DESCRIPTION
In that case, we won't send an additional rejectionhandled event
