### PR TITLE
The rejectionhandled event doesn't include the reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ This implementation results in promise rejections being marked as **handled** or
     1. Remove _promise_ from the outstanding rejected promises weak set.
     1. Let _event_ be a new trusted `PromiseRejectionEvent` object that does not bubble and is not cancelable, and which has the event name `rejectionhandled`.
     1. Initialise _event_'s `promise` attribute to _promise_.
-    1. Initialise _event_'s `reason` attribute to the value of _promise_'s [[PromiseResult]] internal slot.
+    1. Initialise _event_'s `reason` attribute to undefined.
     1. Dispatch _event_ at the current script's [global object](https://html.spec.whatwg.org/multipage/webappapis.html#global-object).
 
 #### The PromiseRejectionEvent interface


### PR DESCRIPTION
We'd have to keep a weak reference to the reason to avoid leaking
memory, but then it's something undefined and sometimes not. Just make
it always undefined.
