### PR TITLE
Set reason in rejectionhandled event as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ This implementation results in promise rejections being marked as **handled** or
     1. Remove _promise_ from the outstanding rejected promises weak set.
     1. Let _event_ be a new trusted `PromiseRejectionEvent` object that does not bubble and is not cancelable, and which has the event name `rejectionhandled`.
     1. Initialise _event_'s `promise` attribute to _promise_.
+    1. Initialise _event_'s `reason` attribute to the value of _promise_'s [[PromiseResult]] internal slot.
     1. Dispatch _event_ at the current script's [global object](https://html.spec.whatwg.org/multipage/webappapis.html#global-object).
 
 To **notify about rejected promises**, perform the following steps:

--- a/tests/promise-rejection-events-console.html
+++ b/tests/promise-rejection-events-console.html
@@ -29,7 +29,7 @@ async_test(function(t) {
     t.step(function() {
       assert_false(evt.cancelable);
       assert_equals(evt.promise, p);
-      assert_equals(evt.reason, null);
+      assert_equals(evt.reason, e);
     });
     setTimeout(function() {
       if (window.internals) {

--- a/tests/resources/promise-rejection-events.js
+++ b/tests/resources/promise-rejection-events.js
@@ -486,7 +486,7 @@ async_test(function(t) {
         assert_array_equals(unhandledPromises, [p]);
         assert_array_equals(unhandledReasons, [e]);
         assert_equals(ev.promise, p);
-        assert_equals(ev.reason, null);
+        assert_equals(ev.reason, e);
       });
     }
   };


### PR DESCRIPTION
Turns out it is possible to implement this in blink after all.
