### PR TITLE
Conditionally queue a task to notify

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,7 @@ _NOTE:_ Implementations are free to limit the size of the rejected promises weak
 
 Insert a step between steps 8 and 9:
 
-1. _Done:_ If the about-to-be-notified rejected promises list is not empty,
-  1. Queue a task to <a href="#user-content-notify-about-rejected-promises">notify about the rejected promises</a> currently in the about-to-be-notified rejected promises list.
-  1. Clear the about-to-be-notified rejected promises list.
+1. _Done:_ If the about-to-be-notified rejected promises list is not empty, queue a task to <a href="#user-content-notify-about-rejected-promises">notify about rejected promises</a>.
 
 Modify step 9 to remove the "_Done:_" label from it.
 
@@ -99,15 +97,16 @@ ECMAScript contains an implementation-defined HostPromiseRejectionTracker(_promi
 
 #### Notification of rejected promises
 
-To <a id="notify-about-rejected-promises">**notify about a list of rejected promises**</a>, given a list _list_, perform the following steps:
+To <a id="notify-about-rejected-promises">**notify about rejected promises**</a>, perform the following steps:
 
-1. For each entry _p_ in _list_,
+1. For each entry _p_ in the about-to-be-notified rejected promises list,
     1. Let _event_ be a new trusted `PromiseRejectionEvent` object that does not bubble and is cancelable, and which has the event name `unhandledrejection`.
     1. Initialise _event_'s `promise` attribute to _p_.
     1. Initialise _event_'s `reason` attribute to the value of _p_'s [[PromiseResult]] internal slot.
     1. Dispatch _event_ at the current script's [global object](https://html.spec.whatwg.org/multipage/webappapis.html#global-object).
     1. If event was canceled, then the promise rejection is handled. Otherwise, the promise rejection is not handled.
     1. If _p_'s [[PromiseIsHandled]] internal slot is false, add _p_ to the outstanding rejected promises weak set.
+1. Clear the about-to-be-notified rejected promises list.
 
 This implementation results in promise rejections being marked as **handled** or **not handled**. These concepts parallel handled and not handled for [script errors](https://html.spec.whatwg.org/multipage/webappapis.html#concept-error-handled).
 

--- a/README.md
+++ b/README.md
@@ -68,9 +68,11 @@ Environment settings object seems to be a place to dump stuff? Need to define th
 
 Insert a step between steps 8 and 9:
 
-1. If the about-to-be-notified rejected promises list is not empty, and the will notify about rejected promises flag is unset,
+1. _Done:_ If the about-to-be-notified rejected promises list is not empty, and the will notify about rejected promises flag is unset,
   1. Queue a task to <a href="#user-content-notify-about-rejected-promises">notify about rejected promises</a>.
   1. Set the will notify about rejected promises flag.
+
+Modify step 9 to remove the "_Done:_" label from it.
 
 ### Unhandled promise rejections
 

--- a/README.md
+++ b/README.md
@@ -62,14 +62,15 @@ Environment settings object seems to be a place to dump stuff? Need to define th
 
 - Outstanding rejected promises weak set
 - About-to-be-notified rejected promises list
+- Will notify about rejected promises flag
 
 ### [Perform a microtask checkpoint](https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint)
 
 Insert a step between steps 8 and 9:
 
-1. _Done:_ <a href="#user-content-notify-about-rejected-promises">Notify about rejected promises</a>.
-
-Remove the "_Done:_" label from step 9.
+1. If the about-to-be-notified rejected promises list is not empty, and the will notify about rejected promises flag is unset,
+  1. Queue a task to <a href="#user-content-notify-about-rejected-promises">notify about rejected promises</a>.
+  1. Set the will notify about rejected promises flag.
 
 ### Unhandled promise rejections
 
@@ -98,6 +99,7 @@ This implementation results in promise rejections being marked as **handled** or
 
 To <a id="notify-about-rejected-promises">**notify about rejected promises**</a>, perform the following steps:
 
+1. Unset the will notify about rejected promises flag.
 1. For each entry _p_ in the about-to-be-notified rejected promises list,
     1. Let _event_ be a new trusted `PromiseRejectionEvent` object that does not bubble and is cancelable, and which has the event name `unhandledrejection`.
     1. Initialise _event_'s `promise` attribute to _p_.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Environment settings object seems to be a place to dump stuff? Need to define th
 - Outstanding rejected promises weak set
 - About-to-be-notified rejected promises list
 
+_NOTE:_ Implementations are free to limit the size of the rejected promises weak set.
+
 ### [Perform a microtask checkpoint](https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint)
 
 Insert a step between steps 8 and 9:
@@ -82,8 +84,6 @@ In addition to synchronous [runtime script errors](https://html.spec.whatwg.org/
 #### The HostPromiseRejectionTracker implementation
 
 ECMAScript contains an implementation-defined HostPromiseRejectionTracker(_promise_, _operation_) abstract operation. User agents must use the following implementation.
-
-This implementation results in promise rejections being marked as **handled** or **unhandled**. These concepts parallel handled and not handled for [script errors](https://html.spec.whatwg.org/multipage/webappapis.html#concept-error-handled).
 
 1. If _operation_ is `"reject"`,
     1. Add _promise_ to the about-to-be-notified rejected promises list.
@@ -105,8 +105,12 @@ To <a id="notify-about-rejected-promises">**notify about a list of rejected prom
     1. Initialise _event_'s `promise` attribute to _p_.
     1. Initialise _event_'s `reason` attribute to the value of _p_'s [[PromiseResult]] internal slot.
     1. Dispatch _event_ at the current script's [global object](https://html.spec.whatwg.org/multipage/webappapis.html#global-object).
-    1. If event was canceled, then the promise rejection is handled. Otherwise, the promise rejection is unhandled.
+    1. If event was canceled, then the promise rejection is handled. Otherwise, the promise rejection is not handled.
     1. If _p_'s [[PromiseIsHandled]] internal slot is false, add _p_ to the outstanding rejected promises weak set.
+
+This implementation results in promise rejections being marked as **handled** or **not handled**. These concepts parallel handled and not handled for [script errors](https://html.spec.whatwg.org/multipage/webappapis.html#concept-error-handled).
+
+_NOTE:_ Implementations should use the handled/not handled state of promise rejections when determining what to log in any debugging interfaces. That is, intercepting an `unhandledrejection` event and calling `preventDefault()` should prevent the corresponding rejection from showing up in the developer console or similar.
 
 #### The PromiseRejectionEvent interface
 
@@ -144,9 +148,3 @@ Add
   attribute EventHandler onunhandledrejection;
   attribute EventHandler onrejectionhandled;
 ```
-
-### Notes
-
-- Implementations should use the handled/unhandled state of promise rejections (as defined in HTML) when determining what to log on the console. That is, intercepting an `unhandledrejection` event and calling `preventDefault()` should prevent the corresponding rejection from showing up in the developer console.
-
-- Implementations are free to limit the size of the rejected promises weak set.

--- a/README.md
+++ b/README.md
@@ -91,10 +91,11 @@ ECMAScript contains an implementation-defined HostPromiseRejectionTracker(_promi
     1. If the about-to-be-notified rejected promises list contains _promise_, remove _promise_ from the about-to-be-notified rejected promises list and return.
     1. If the outstanding rejected promises weak set does not contain _promise_ then return.
     1. Remove _promise_ from the outstanding rejected promises weak set.
-    1. Let _event_ be a new trusted `PromiseRejectionEvent` object that does not bubble and is not cancelable, and which has the event name `rejectionhandled`.
-    1. Initialise _event_'s `promise` attribute to _promise_.
-    1. Initialise _event_'s `reason` attribute to the value of _promise_'s [[PromiseResult]] internal slot.
-    1. Dispatch _event_ at the current script's [global object](https://html.spec.whatwg.org/multipage/webappapis.html#global-object).
+    1. Queue a task to perform the following steps:
+        1. Let _event_ be a new trusted `PromiseRejectionEvent` object that does not bubble and is not cancelable, and which has the event name `rejectionhandled`.
+        1. Initialise _event_'s `promise` attribute to _promise_.
+        1. Initialise _event_'s `reason` attribute to the value of _promise_'s [[PromiseResult]] internal slot.
+        1. Dispatch _event_ at the current script's [global object](https://html.spec.whatwg.org/multipage/webappapis.html#global-object).
 
 #### Notification of rejected promises
 

--- a/README.md
+++ b/README.md
@@ -62,15 +62,14 @@ Environment settings object seems to be a place to dump stuff? Need to define th
 
 - Outstanding rejected promises weak set
 - About-to-be-notified rejected promises list
-- Will notify about rejected promises flag
 
 ### [Perform a microtask checkpoint](https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint)
 
 Insert a step between steps 8 and 9:
 
-1. _Done:_ If the about-to-be-notified rejected promises list is not empty, and the will notify about rejected promises flag is unset,
-  1. Queue a task to <a href="#user-content-notify-about-rejected-promises">notify about rejected promises</a>.
-  1. Set the will notify about rejected promises flag.
+1. _Done:_ If the about-to-be-notified rejected promises list is not empty,
+  1. Queue a task to <a href="#user-content-notify-about-rejected-promises">notify about the rejected promises</a> currently in the about-to-be-notified rejected promises list.
+  1. Clear the about-to-be-notified rejected promises list.
 
 Modify step 9 to remove the "_Done:_" label from it.
 
@@ -99,17 +98,15 @@ This implementation results in promise rejections being marked as **handled** or
 
 #### Notification of rejected promises
 
-To <a id="notify-about-rejected-promises">**notify about rejected promises**</a>, perform the following steps:
+To <a id="notify-about-rejected-promises">**notify about a list of rejected promises**</a>, given a list _list_, perform the following steps:
 
-1. Unset the will notify about rejected promises flag.
-1. For each entry _p_ in the about-to-be-notified rejected promises list,
+1. For each entry _p_ in _list_,
     1. Let _event_ be a new trusted `PromiseRejectionEvent` object that does not bubble and is cancelable, and which has the event name `unhandledrejection`.
     1. Initialise _event_'s `promise` attribute to _p_.
     1. Initialise _event_'s `reason` attribute to the value of _p_'s [[PromiseResult]] internal slot.
     1. Dispatch _event_ at the current script's [global object](https://html.spec.whatwg.org/multipage/webappapis.html#global-object).
     1. If event was canceled, then the promise rejection is handled. Otherwise, the promise rejection is unhandled.
     1. If _p_'s [[PromiseIsHandled]] internal slot is false, add _p_ to the outstanding rejected promises weak set.
-1. Clear the about-to-be-notified rejected promises list.
 
 #### The PromiseRejectionEvent interface
 

--- a/tests/resources/promise-rejection-events.js
+++ b/tests/resources/promise-rejection-events.js
@@ -844,12 +844,16 @@ function onUnhandledSucceed(t, expectedReason, expectedPromiseGetter) {
 function onUnhandledFail(t, expectedPromiseGetter) {
   var unhandled = function(evt) {
     if (evt.promise === expectedPromiseGetter()) {
-      t.unreached_func('unhandledrejection event is not supposed to be triggered');
+      t.step(function() {
+        assert_unreached('unhandledrejection event is not supposed to be triggered');
+      });
     }
   };
   var handled = function(evt) {
     if (evt.promise === expectedPromiseGetter()) {
-      t.unreached_func('rejectionhandled event is not supposed to be triggered');
+      t.step(function() {
+        assert_unreached('rejectionhandled event is not supposed to be triggered');
+      });
     }
   };
   addEventListener('unhandledrejection', unhandled);

--- a/tests/resources/promise-rejection-events.js
+++ b/tests/resources/promise-rejection-events.js
@@ -700,8 +700,9 @@ async_test(function(t) {
   function checkSequence() {
     if (sequenceOfEvents.length === 3) {
       t.step(function() {
-        assert_array_equals(sequenceOfEvents, [p1, p2, 'postMessageTask']);
+        assert_array_equals(sequenceOfEvents, [p1, 'postMessageTask', p2]);
       });
+      t.done();
     }
   }
 }, 'postMessageTask ordering vs. the task queued for unhandled rejection notification (1)');
@@ -731,6 +732,7 @@ async_test(function(t) {
       t.step(function() {
         assert_array_equals(sequenceOfEvents, ['postMessageTask', p2]);
       });
+      t.done();
     }
   }
 }, 'postMessageTask ordering vs. the task queued for unhandled rejection notification (2)');


### PR DESCRIPTION
<del>This is option 5 in @bzbarsky's https://github.com/domenic/unhandled-rejections-browser-spec/issues/2#issuecomment-120582936. Some test cases change since now we allow a bit more delay before attachment.</del><ins>Option 3 in play now, plus a few other changes.</ins>

See more discussion over in that thread. If we decide it is a good change, then review of this would be much appreciated before pulling it in, especially in the form of @jeisinger trying it in Blink :)
